### PR TITLE
Feature/option for callback

### DIFF
--- a/Example App/iOS Example App/Controllers/ViewController.swift
+++ b/Example App/iOS Example App/Controllers/ViewController.swift
@@ -124,4 +124,8 @@ extension ViewController: MCEmojiPickerDelegate {
     func didGetEmoji(emoji: String) {
         emojiButton.setTitle(emoji, for: .normal)
     }
+    
+    func didClose() {
+        // no-op
+    }
 }

--- a/Sources/MCEmojiPicker/View/MCEmojiPickerViewController.swift
+++ b/Sources/MCEmojiPicker/View/MCEmojiPickerViewController.swift
@@ -27,6 +27,8 @@ public protocol MCEmojiPickerDelegate: AnyObject {
     func didClose()
 }
 
+public typealias MCEmojiPickerCompletion = (String?) -> Void
+
 public final class MCEmojiPickerViewController: UIViewController {
     
     // MARK: - Public Properties
@@ -96,9 +98,12 @@ public final class MCEmojiPickerViewController: UIViewController {
         return MCEmojiPickerView(categoryTypes: categories, delegate: self)
     }()
     
+    private var completion: MCEmojiPickerCompletion?
+    
     // MARK: - Initializers
     
-    public init() {
+    public init(completion: MCEmojiPickerCompletion? = nil) {
+        self.completion = completion
         super.init(nibName: nil, bundle: nil)
         setupPopoverPresentationStyle()
         setupDelegates()
@@ -129,6 +134,7 @@ public final class MCEmojiPickerViewController: UIViewController {
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         delegate?.didClose()
+        completion?(nil)
         NotificationCenter.default.post(name: .MCEmojiPickerDidDisappear, object: nil)
     }
     
@@ -139,7 +145,11 @@ public final class MCEmojiPickerViewController: UIViewController {
             guard let emoji = emoji else { return }
             feedbackImpactOccurred()
             delegate?.didGetEmoji(emoji: emoji.string)
+            completion?(emoji.string)
+            
             if isDismissAfterChoosing {
+                //clear completion so that it's not called mutltiple times
+                completion = nil
                 dismiss(animated: true, completion: nil)
             }
         }

--- a/Sources/MCEmojiPicker/View/MCEmojiPickerViewController.swift
+++ b/Sources/MCEmojiPicker/View/MCEmojiPickerViewController.swift
@@ -24,6 +24,7 @@ import UIKit
 
 public protocol MCEmojiPickerDelegate: AnyObject {
     func didGetEmoji(emoji: String)
+    func didClose()
 }
 
 public final class MCEmojiPickerViewController: UIViewController {
@@ -127,6 +128,7 @@ public final class MCEmojiPickerViewController: UIViewController {
     
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        delegate?.didClose()
         NotificationCenter.default.post(name: .MCEmojiPickerDidDisappear, object: nil)
     }
     


### PR DESCRIPTION
This PR improves 2 things:
1) It adds an option to use callback instead of delegate
2) It adds `didClose()` delegate method.

Since `MCEmojiPickerDidDisappear` is internal, there was no way for caller to know when emoji picker was dismissed. 